### PR TITLE
Replaced specific hash reference with wildcard reference

### DIFF
--- a/library.json
+++ b/library.json
@@ -6,7 +6,7 @@
     "platforms": "*",
     "dependencies":
     {
-      "shared_firmware_types": "https://github.com/hytech-racing/shared_firmware_types.git#f976ebd",
+      "shared_firmware_types": "*",
       "FlexCAN_T4": "https://github.com/tonton81/FlexCAN_T4",
       "Embedded Template Library": "https://github.com/ETLCPP/etl.git"
     }


### PR DESCRIPTION
We've been updating shared_firmware_interfaces every time we add a new commit to shared_firmware_types, since we need to point to new commit. By replacing the specific commit hash with "*", it'll still require that upstream dependency, but will not go clone it.