### PR TITLE
fix: make the dependent member function looked up and consider the base class

### DIFF
--- a/include/MCP_ADC.tpp
+++ b/include/MCP_ADC.tpp
@@ -13,7 +13,7 @@ MCP_ADC<MCP_ADC_NUM_CHANNELS>::MCP_ADC(const int spiPinCS, const int spiPinSDI, 
     for (int i = 0; i < MCP_ADC_NUM_CHANNELS; i++)
     {
         MCP_ADC<MCP_ADC_NUM_CHANNELS>::_channels[i] = AnalogChannel();
-        setChannelScaleAndOffset(i, scales[i], offsets[i]);
+        this->setChannelScaleAndOffset(i, scales[i], offsets[i]);
     }
     pinMode(_spiPinCS, OUTPUT);
     digitalWrite(_spiPinCS, HIGH);


### PR DESCRIPTION
as seen here: https://godbolt.org/z/PdGGPr4ox

and explained here: https://www.modernescpp.com/index.php/surprise-included-inheritance-and-member-functions-of-class-templates/